### PR TITLE
Update repo naming and links after changing from 'ckeditor-dev' to 'ckeditor4' etc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ckeditor"]
 	path = ckeditor
-	url = https://github.com/ckeditor/ckeditor-dev.git
+	url = https://github.com/ckeditor/ckeditor4.git
 [submodule "plugins/wsc"]
 	path = plugins/wsc
 	url = https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The original source code from the official CKEditor repositories is used for the
 
 To clone this code:
 
-	> git clone https://github.com/ckeditor/ckeditor-presets.git
+	> git clone https://github.com/ckeditor/ckeditor4-presets.git
 
 Then, the registered submodules need to be updated:
 
@@ -25,7 +25,7 @@ This is the command syntax:
 
 	> build.sh standard|basic|full [all]
 
-The optional "all" argument tells the builder to include all plugins available in the ckeditor-dev repository, even if they're not included in the preset.
+The optional "all" argument tells the builder to include all plugins available in the `ckeditor4` repository, even if they're not included in the preset.
 
 The build will be then created in the `build/[preset name]` folder.
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 # Move to the script directory.
 cd $(dirname $0)
 
-# Use the ckeditor-dev commit hash as the revision.
+# Use the ckeditor4 commit hash as the revision.
 cd ckeditor/
 rev=`git rev-parse --verify --short HEAD`
 CKEDITOR_VERSION=`node -pe "require('./package.json').version"`

--- a/presets/README.md
+++ b/presets/README.md
@@ -2,23 +2,23 @@ CKEditor 4
 ==========
 
 Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
-http://ckeditor.com - See LICENSE.md for license information.
+https://ckeditor.com - See LICENSE.md for license information.
 
-CKEditor is a text editor to be used inside web pages. It's not a replacement
+CKEditor 4 is a text editor to be used inside web pages. It's not a replacement
 for desktop text editors like Word or OpenOffice, but a component to be used as
 part of web applications and websites.
 
 ## Documentation
 
 The full editor documentation is available online at the following address:
-http://docs.ckeditor.com
+https://ckeditor.com/docs/
 
 ## Installation
 
 Installing CKEditor is an easy task. Just follow these simple steps:
 
  1. **Download** the latest version from the CKEditor website:
-    http://ckeditor.com. You should have already completed this step, but be
+    https://ckeditor.com. You should have already completed this step, but be
     sure you have the very latest version.
  2. **Extract** (decompress) the downloaded file into the root of your website.
 


### PR DESCRIPTION
Part of the cleanup.

[Link](https://github.com/ckeditor/ckeditor4/issues/3518) to particular issue in CKEditor4 repo.

[Link](https://github.com/ckeditor/ckeditor4/issues/2793) to a broader discussion after rename.