### PR TITLE
Add editorplaceholder plugin to full preset

### DIFF
--- a/presets/full-build-config.js
+++ b/presets/full-build-config.js
@@ -44,6 +44,7 @@ var CKBUILDER_CONFIG = {
 		contextmenu: 1,
 		dialogadvtab: 1,
 		div: 1,
+		editorplaceholder: 1,
 		elementspath: 1,
 		enterkey: 1,
 		entities: 1,


### PR DESCRIPTION
I've added `editorplaceholder` plugin to full preset.

Closes #35.