### PR TITLE
Build script now supports copying tests for external plugins

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,6 +134,20 @@ if [[ "$ARGS" == *\ \-t\ * ]]; then
 	cp ckeditor/bender.js $target/ckeditor/bender.js
 
 	echo ""
+	echo "Copying External Plugins tests..."
+
+	for dir in plugins/*/
+	do
+		dir=${dir%*/}
+		dir=${dir##*/}
+
+		if [ -d "plugins/$dir/tests" ]; then
+			cp -r "plugins/$dir/tests" "$target/ckeditor/plugins/$dir/tests"
+			echo "- copied tests for $dir plugin"
+		fi
+	done
+
+	echo ""
 	echo "Copying MathJax library..."
 
 	if [ -d "$MATHJAX_LIB_PATH" ]; then

--- a/build.sh
+++ b/build.sh
@@ -143,7 +143,7 @@ if [[ "$ARGS" == *\ \-t\ * ]]; then
 
 		if [ -d "plugins/$dir/tests" ]; then
 			cp -r "plugins/$dir/tests" "$target/ckeditor/plugins/$dir/tests"
-			echo "- copied tests for $dir plugin"
+			echo "    $dir"
 		fi
 	done
 


### PR DESCRIPTION
As we are planning to add support for testing external plugins, I have adjusted build script to also copy those tests (if `-t` flag is present). This is a part of bigger task, see also ckeditor/ckeditor4#4234.

### How to test - only this change?

1.  Add any plugin with tests to `/plugins/` directory (or just some fake test to \`wsc\`, \`scayt\` plugins).
2.  Run `build.sh full all -t`.

The `tests` folder should be present in resulted CKEditor 4 build (so under `build/version/full-all/ckeditor/plugins/plugin-name/tests/`).

### How to test - entire workflow?

1.  Switch to this branch.
2.  Replace `ckeditor` submodule with your local `ckeditor4` copy (switched to `t/load-external` branch - see ckeditor/ckeditor4#4234).
3.  Checkout Export to PDF plugin repo somewhere (on `t/79` branch) and build dist version (`npm i && npm build`).
4.  Copy Export to PDF plugin dist folder and tests to `/plugins/` folder like:
    *   `cp -r .../ckeditor4-plugin-pdfexport/dist /plugins/exportpdf`
    *   `cp -r .../ckeditor4-plugin-pdfexport/tests/ /plugins/exportpdf/tests/`
5. Build `full-all` preset - `build.sh full all -t`.
6. Go to build folder and run bender tests.

All unit and manual tests for Export to PDF plugin should be there and should pass the same way they pass when run from external repo (so basically just pass).