### PR TITLE
Introduce NPM packages as External Plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build
 /ckbuilder
+
+node_modules/

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,18 @@
 
 # Build CKEditor using the default settings (and build.js)
 
+# Install NPM deps and move external plugins from `node_modules` to `plugins` directory.
+echo ""
+echo "Installing NPM dependencies..."
+
+npm i
+
+echo ""
+echo "Copying plugins from NPM directory..."
+echo ""
+
+cp -r  "node_modules/ckeditor4-plugin-exportpdf" "plugins/exportpdf"
+
 # Move to the script directory.
 cd $(dirname $0)
 
@@ -165,6 +177,11 @@ if [[ "$ARGS" == *\ \-t\ * ]]; then
 	(cd $target/ckeditor &&	npm install && bender init)
 fi
 
+# Clean up `plugins` directory from copied NPM plugins.
+echo ""
+echo "Cleaning plugins directory from NPM artifacts..."
+
+rm -rf "plugins/exportpdf"
 
 echo ""
 echo "Build created into the \"build\" directory."

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ckeditor4-presets",
+  "version": "4.15.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ckeditor4-plugin-exportpdf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.0.tgz",
+      "integrity": "sha512-3Q6xAQ2Jxf4VQAz6SDgVVxfW/RijJhIdGHrrCti5lpMoD4rSk/McydfchxNkIPyp/WZHZFXhdCg7jeyHiQOXyg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://ckeditor.com",
   "dependencies": {
-    "ckeditor4-plugin-exportpdf": "^1.0.0"
+    "ckeditor4-plugin-exportpdf": "1.0.0"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ckeditor4-presets",
+  "version": "4.15.0",
+  "description": "CKEditor 4 Presets Builder.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "ckeditor4",
+    "ckeditor",
+    "fckeditor",
+    "editor",
+    "wysiwyg",
+    "html",
+    "richtext",
+    "text",
+    "javascript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ckeditor/ckeditor4-presets.git"
+  },
+  "author": "CKSource (https://cksource.com/)",
+  "license": "(GPL-2.0-or-later OR LGPL-2.1 OR MPL-1.1)",
+  "bugs": {
+    "url": "https://github.com/ckeditor/ckeditor4-presets/issues"
+  },
+  "homepage": "https://ckeditor.com",
+  "dependencies": {
+    "ckeditor4-plugin-exportpdf": "^1.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
   "homepage": "https://ckeditor.com",
   "dependencies": {
     "ckeditor4-plugin-exportpdf": "^1.0.0"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
So tho whole change required adding `package.json` (which wasn't there :scream: ). We could do this without it (e.g. running `npm i name --no-save --something-something`) but I think it will be useful in the future.

I'm not sure about package version, if ti should be aligned with CKEditor 4 version or just something like `1.0.0` or `0.0.1`, WDYT?

I also added `private: true` which prevents from publishing this as package by mistake.

Now, one more thing is why `npm i` is a part of build process? We have some other tools like docs, online builder, etc. which uses presets in a way that they run git submodules update and then build. Adding separate step which is not a part of build process will require changes in all related tools (so kind of a breaking change). Adding `npm i` as a build step makes this change backwards compatible.

Another thing is that, this change assumes that build process is run in an env where `npm` command is available. It was partially true before (for `-t` flag) so I hope it won't cause any issues.