### PR TITLE
Copy external plugins tests only if plugin exists in preset destination directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,7 +153,7 @@ if [[ "$ARGS" == *\ \-t\ * ]]; then
 		dir=${dir%*/}
 		dir=${dir##*/}
 
-		if [ -d "plugins/$dir/tests" ]; then
+		if [ -d "plugins/$dir/tests" ] && [ -d "$target/ckeditor/plugins/$dir" ]; then
 			cp -r "plugins/$dir/tests" "$target/ckeditor/plugins/$dir/tests"
 			echo "    $dir"
 		fi


### PR DESCRIPTION
Since it was failing for presets without the plugin:

![](https://user-images.githubusercontent.com/1061942/91964950-1709cf80-ed10-11ea-894d-407f87fc099b.png)

I added a check if destination plugin directory exists too.