### PR TITLE
Update Export to PDF plugin to 1.0.1 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#release.5.7.0.0"
     },
     "ckeditor4-plugin-exportpdf": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.0.tgz",
-      "integrity": "sha512-3Q6xAQ2Jxf4VQAz6SDgVVxfW/RijJhIdGHrrCti5lpMoD4rSk/McydfchxNkIPyp/WZHZFXhdCg7jeyHiQOXyg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.1.tgz",
+      "integrity": "sha512-KJS2G89Keid+bwYGORsjmo4rct2U0zhI/SClpGySKi4jxo8G5aH968Zlur56F8wA+WiTbXvxeU4yli7Rdfe6FA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://ckeditor.com",
   "dependencies": {
-    "ckeditor4-plugin-exportpdf": "1.0.0",
+    "ckeditor4-plugin-exportpdf": "1.0.1",
     "ckeditor-plugin-scayt": "https://github.com/WebSpellChecker/ckeditor-plugin-scayt#release.5.7.0.0",
     "ckeditor-plugin-wsc": "https://github.com/WebSpellChecker/ckeditor-plugin-wsc#release.5.7.0.0"
   }


### PR DESCRIPTION
Changes in `1.0.1` vs `1.0.0` were very minor so I assume we can bump it safely - https://github.com/cksource/ckeditor4-plugin-exportpdf/compare/v1.0.0...v1.0.1.

Let's wait for the CI and if it's green I will check rest of the browsers too.