### PR TITLE
Remove WSC plugin from Demo preset

### DIFF
--- a/presets/demo-build-config.js
+++ b/presets/demo-build-config.js
@@ -104,7 +104,6 @@ var CKBUILDER_CONFIG = {
 		'undo' : 1,
 		'uploadfile' : 1,
 		'uploadimage' : 1,
-		'wsc' : 1,
 		'wysiwygarea' : 1
 	},
 	languages : {

--- a/presets/demo-ckeditor-config.js
+++ b/presets/demo-ckeditor-config.js
@@ -26,10 +26,6 @@ CKEDITOR.editorConfig = function( config ) {
 		{ name: 'about' }
 	];
 
-	// WebSpellChecker Dialog plugin is approaching the end of life
-	// and is disabled by default.
-	config.removePlugins = 'wsc';
-
 	// Remove some buttons provided by the standard plugins, which are
 	// not needed in the Standard(s) toolbar.
 	config.removeButtons = 'Underline,Subscript,Superscript';

--- a/presets/demo-ckeditor-config.js
+++ b/presets/demo-ckeditor-config.js
@@ -26,6 +26,10 @@ CKEDITOR.editorConfig = function( config ) {
 		{ name: 'about' }
 	];
 
+	// WebSpellChecker Dialog plugin is approaching the end of life
+	// and is disabled by default.
+	config.removePlugins = 'wsc';
+
 	// Remove some buttons provided by the standard plugins, which are
 	// not needed in the Standard(s) toolbar.
 	config.removeButtons = 'Underline,Subscript,Superscript';


### PR DESCRIPTION
As stated in the issue, plugin is actually still in presets, but excluded in config using removePlugins property.

However, currently the `demo` preset seems to be broken (or I can't use it 🤔 ) - after building the sample doesn't work, the plugins that the preset contains are odd and don't match anything. I'm not sure if I should fix this in this PR, or create a separate one.

Closes #54.