### PR TITLE
Bump scayt & wsc dependencies to commit SHA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "ckeditor-plugin-scayt": {
-      "version": "git+https://github.com/WebSpellChecker/ckeditor-plugin-scayt.git#d8d75c3447fe84f5ef7615078703869af541c5aa",
-      "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-scayt.git#release.5.7.0.0"
+      "version": "git+https://github.com/WebSpellChecker/ckeditor-plugin-scayt.git#0e3a94a7db581f8773266563ee6c6536cab412a9",
+      "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-scayt.git#0e3a94a7db581f8773266563ee6c6536cab412a9"
     },
     "ckeditor-plugin-wsc": {
-      "version": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#db9a829a4aead06106c65d102546b912e848d2d0",
-      "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#release.5.7.0.0"
+      "version": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#fef16e9fcab7cb0ce54ec945e7c4d820a803adb0",
+      "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#fef16e9fcab7cb0ce54ec945e7c4d820a803adb0"
     },
     "ckeditor4-plugin-exportpdf": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://ckeditor.com",
   "dependencies": {
     "ckeditor4-plugin-exportpdf": "1.0.1",
-    "ckeditor-plugin-scayt": "https://github.com/WebSpellChecker/ckeditor-plugin-scayt#release.5.7.0.0",
-    "ckeditor-plugin-wsc": "https://github.com/WebSpellChecker/ckeditor-plugin-wsc#release.5.7.0.0"
+    "ckeditor-plugin-scayt": "https://github.com/WebSpellChecker/ckeditor-plugin-scayt#0e3a94a7db581f8773266563ee6c6536cab412a9",
+    "ckeditor-plugin-wsc": "https://github.com/WebSpellChecker/ckeditor-plugin-wsc#fef16e9fcab7cb0ce54ec945e7c4d820a803adb0"
   }
 }


### PR DESCRIPTION
According to [https://github.com/ckeditor/ckeditor4/issues/4368#issuecomment-755948596](https://github.com/ckeditor/ckeditor4/issues/4368#issuecomment-755948596)

SCAYT & WSC plugins versions were updated to commit (not TAG) with our changes: `@skipsource` was added to API docs.  
  
Both plugins were marked with new version tags, but those tags still targeting old commits.  
  
Closes ckeditor/ckeditor4#4368