### PR TITLE
Bump exportpdf-plugin version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       "from": "git+https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git#fef16e9fcab7cb0ce54ec945e7c4d820a803adb0"
     },
     "ckeditor4-plugin-exportpdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.2.tgz",
-      "integrity": "sha512-O9PugzVvGzVMUxSWvYbMy/t0lGhKHEvMTeSIZUzZ8BB9Js+CUScGInNFxZ2axmZHta7kEJ/qXEAkGTexhfsY+w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ckeditor4-plugin-exportpdf/-/ckeditor4-plugin-exportpdf-1.0.3.tgz",
+      "integrity": "sha512-RON0lPIBoR3Q3o09+qjrj9n5jf6fCcHjr+MY4XqcqL53MzLNEtn/ffqGqkFpTampRBtSQGVj/v6k7vxTMN28Cg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://ckeditor.com",
   "dependencies": {
-    "ckeditor4-plugin-exportpdf": "1.0.2",
+    "ckeditor4-plugin-exportpdf": "1.0.3",
     "ckeditor-plugin-scayt": "https://github.com/WebSpellChecker/ckeditor-plugin-scayt#0e3a94a7db581f8773266563ee6c6536cab412a9",
     "ckeditor-plugin-wsc": "https://github.com/WebSpellChecker/ckeditor-plugin-wsc#fef16e9fcab7cb0ce54ec945e7c4d820a803adb0"
   }


### PR DESCRIPTION
Bump exportpdf-plugin to 1.0.3. Newest version fixes failing tests for FF (cksource/ckeditor4-plugin-exportpdf#98)