### PR TITLE
Remove flash plugin from full build config

### DIFF
--- a/presets/full-build-config.js
+++ b/presets/full-build-config.js
@@ -53,7 +53,6 @@ var CKBUILDER_CONFIG = {
 		exportpdf: 1,
 		filebrowser: 1,
 		find: 1,
-		flash: 1,
 		floatingspace: 1,
 		font: 1,
 		format: 1,


### PR DESCRIPTION
The `flash` plugin has been removed from the build configuration file.

After removing it, the build still works fine and I don't see any issue with this change.