### PR TITLE
Handle unsupported JDK version error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,8 +49,15 @@ CKBUILDER_VERSION="2.4.2"
 CKBUILDER_URL="https://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuilder.jar"
 MATHJAX_LIB_PATH="../mathjax/2.2"
 
+RED='\033[0;31m'
+GREEN='\033[01;32m'
+YELLOW='\033[01;33m'
+UNDERLINE='\033[4m'
+RESET_STYLE='\033[0m'
+
 MSG_UPDATE_FAILED="Warning: The attempt to update ckbuilder.jar failed. The existing file will be used."
 MSG_DOWNLOAD_FAILED="It was not possible to download ckbuilder.jar"
+MSG_INCORRECT_JDK_VERSION="${RED}Your JDK version is not supported, there may be a problem to finish build process. Please change the JDK version to 15 or lower.${RED} ${GREEN}https://jdk.java.net/archive/${GREEN}"
 
 PROGNAME=$(basename "$0")
 ARGS=" $@ "
@@ -139,7 +146,21 @@ rm -rf $target
 echo ""
 echo "Building the '$1' preset..."
 
-java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target $skip $require_plugin --version="$CKEDITOR_VERSION ($name)" --revision $rev --build-config presets/$1-build-config.js --no-zip --no-tar --overwrite $JAVA_ARGS
+jdk_version=$( echo `java -version 2>&1 | grep 'version' 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}'` | bc -l)
+regex='^[0-9]+$'
+# Builder is crashing when JDK version is newer than 15.
+if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
+	echo -e "${MSG_INCORRECT_JDK_VERSION}"
+	echo -e "${UNDERLINE}${YELLOW}Actual version of JDK: ${jdk_version}${RESET_STYLE}"
+fi
+
+{
+	java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target $skip $require_plugin --version="$CKEDITOR_VERSION ($name)" --revision $rev --build-config presets/$1-build-config.js --no-zip --no-tar --overwrite $JAVA_ARGS
+} || {
+	if ! [[ $jdk_version =~ $regex ]] || [ $jdk_version -gt 15 ]; then
+		echo -e "\n${RED}The build has been stopped. Please verify the eventual error messages above.${RESET_STYLE}"
+	fi
+}
 
 cp presets/$1-ckeditor-config.js $target/ckeditor/config.js
 cp presets/README.md $target/ckeditor/


### PR DESCRIPTION
Handle unsupported JDK version like in the `ckeditor4` repo
see: https://github.com/ckeditor/ckeditor4/pull/4932

Closes #69 