### PR TITLE
Lock gh actions versions in CI Pipelines

### DIFF
--- a/.github/workflows/setup-workflows.yml
+++ b/.github/workflows/setup-workflows.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
 
@@ -56,18 +56,18 @@ jobs:
       - name: Cancel build if update branch already exists
         if: env.SHOULD_CANCEL == 1
         # https://github.com/marketplace/actions/cancel-this-build
-        uses: andymckay/cancel-action@0.2
+        uses: andymckay/cancel-action@8f8510d9dea52fcc8eb6ca10d6ce47fd5fc43cd8 #0.2
 
       - name: Wait for cancellation
         if: env.SHOULD_CANCEL == 1
         # https://github.com/marketplace/actions/wait-sleep
-        uses: jakejarvis/wait-action@master
+        uses: jakejarvis/wait-action@919fc193e07906705e5b7a50f90ea9e74d20b2b0 #v0.1.1
         with:
           time: '60s'
 
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           path: ckeditor4-workflows-common
           repository: ckeditor/ckeditor4-workflows-common
@@ -104,7 +104,7 @@ jobs:
       - name: Push changes
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/github-push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 #v1.0.0
         with:
           github_token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
           branch: ${{ env.BRANCH_SOURCE }}
@@ -112,7 +112,7 @@ jobs:
       - name: Create PR
         if: env.HAS_CHANGES == 1 && env.AS_PR == 1
         # https://github.com/marketplace/actions/github-pull-request-action
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: "${{ env.BRANCH_SOURCE }}"
           destination_branch: "${{ github.ref }}"

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -8,7 +8,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 #v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: "It's been a while since we last heard from you. We are marking this issue as stale due to inactivity. Please provide the requested feedback or the issue will be closed after next 7 days."

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e #v1
         with:
           node-version: '12'
 
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
 
       - name: Read config
         run: |
@@ -88,7 +88,7 @@ jobs:
       - name: Push changes
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/github-push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 #v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.BRANCH_UPDATE }}
@@ -96,7 +96,7 @@ jobs:
       - name: Create PR
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/github-pull-request-action
-        uses: repo-sync/pull-request@v2
+        uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2
         with:
           source_branch: "${{ env.BRANCH_UPDATE }}"
           destination_branch: "${{ env.BRANCH_TARGET }}"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch changes
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           ref: ${{ matrix.branch }}
 
@@ -38,7 +38,7 @@ jobs:
 
       - name: Push changes
         # https://github.com/marketplace/actions/github-push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 #v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ matrix.branch }}


### PR DESCRIPTION
```
Lock gh actions versions in CI Pipelines

This PR gh actions (exact sha) versions in CI Pipelines.

Recent supply chain attacks in popular tools (Trivy, LiteLLM, axios) are 
concerning. There might be more such attacks.

Most of our CI pipelines that use public actions (in case of Github 
Actions workflows) or CircleCI orbs are not locked versions. This means 
that if any of these packages would be released and would be vulnerable, 
our jobs would pull these vulnerable versions. We need to lock the versions to 
protect ourselfs from these kind of attacks.

The sha commits in PR can be resolved and verified in the following way:

there are lightweight tags and they point directly to a sha commit, 
so we can use the sha of the tag itself.

But there are also annotated tags, which are separate git objects and 
they are pointing to commit and have their own sha different from commit.
 
Get the SHA commit for example for configure-aws-credentials@v4:
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4^{}
result

^{} - is automatically derefrerrencing annotated tag to commit SHA, if
result is empty then the tag is not annotated but lightweight -> then:

git ls-remote https://github.com/actions/setup-node refs/tags/v4

gives you the commit sha directly but for 
configure-aws-credentials@v4
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4
gives us the sha of the tag itself, not the commit. 
That's why we need to try dereference the tag first and dereference is 
empty then sha of tag is sha of commit itself. So verification:
1) if 
git ls-remote https://github.com/<org>/<action> refs/tags/<version>^{}
gives result, use it, if not, then:
2) git ls-remote https://github.com/<org>/<action> refs/tags/<version>
use this result.

Touches: https://tiugotech.atlassian.net/browse/TD-1704
```
Touches: https://tiugotech.atlassian.net/browse/TD-1704
